### PR TITLE
Add LaTeX project architecture example

### DIFF
--- a/ARQUITETURA/Makefile
+++ b/ARQUITETURA/Makefile
@@ -1,0 +1,11 @@
+LATEX=pdflatex
+TARGET=build/main.pdf
+SRC=docs/main.tex
+
+all:
+mkdir -p build
+$(LATEX) -output-directory=build $(SRC)
+$(LATEX) -output-directory=build $(SRC)
+
+clean:
+rm -rf build

--- a/ARQUITETURA/README.md
+++ b/ARQUITETURA/README.md
@@ -1,0 +1,3 @@
+# Estrutura LaTeX Modular
+
+Esta pasta demonstra uma organização sugerida para projetos em LaTeX. O documento principal está em `docs/main.tex`, que incorpora as seções em `docs/sections/` e utiliza macros personalizadas em `docs/style/macros.tex`. As referências BibTeX ficam em `docs/bibliography/referencias.bib`. Para compilar o PDF, utilize o `Makefile`.

--- a/ARQUITETURA/docs/bibliography/referencias.bib
+++ b/ARQUITETURA/docs/bibliography/referencias.bib
@@ -1,0 +1,7 @@
+% Exemplo de entrada BibTeX
+@book{exemplo,
+  author    = {Autor Exemplo},
+  title     = {Titulo do Livro},
+  year      = {2023},
+  publisher = {Editora}
+}

--- a/ARQUITETURA/docs/main.tex
+++ b/ARQUITETURA/docs/main.tex
@@ -1,0 +1,9 @@
+\documentclass{article}
+\input{style/macros.tex}
+\begin{document}
+\input{sections/intro.tex}
+\input{sections/fundamentos.tex}
+\input{sections/conclusao.tex}
+\bibliographystyle{plain}
+\bibliography{bibliography/referencias}
+\end{document}

--- a/ARQUITETURA/docs/sections/conclusao.tex
+++ b/ARQUITETURA/docs/sections/conclusao.tex
@@ -1,0 +1,2 @@
+\section{Conclus\~ao}
+Texto de conclus\~ao.

--- a/ARQUITETURA/docs/sections/fundamentos.tex
+++ b/ARQUITETURA/docs/sections/fundamentos.tex
@@ -1,0 +1,2 @@
+\section{Fundamentos}
+Conte\'udo sobre fundamentos.

--- a/ARQUITETURA/docs/sections/intro.tex
+++ b/ARQUITETURA/docs/sections/intro.tex
@@ -1,0 +1,2 @@
+\section{Introdu\c{c}\~ao}
+Texto da introdu\c{c}\~ao.

--- a/ARQUITETURA/docs/style/macros.tex
+++ b/ARQUITETURA/docs/style/macros.tex
@@ -1,0 +1,4 @@
+% Pacotes e comandos personalizados
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{graphicx}


### PR DESCRIPTION
## Summary
- create `ARQUITETURA` folder showing a modular LaTeX project layout
- include example `Makefile`, `README.md`, and skeleton `.tex` files
- provide directories for sections, bibliography, images, and macros

## Testing
- `make` *(fails: pdflatex not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877f8b3947c8324868013e95db55d7d